### PR TITLE
WAIT_TIMEOUT should be 1 second

### DIFF
--- a/server/entrypoint
+++ b/server/entrypoint
@@ -73,7 +73,7 @@ configure() {
 
 # Additional settings added by entrypoint
 AUTOUPDATE_DELAY = 1
-WAIT_TIMEOUT = 10000
+WAIT_TIMEOUT = 1000
 
 DATABASES['mediafiles'] = {
     'ENGINE': 'django.db.backends.postgresql',


### PR DESCRIPTION
the WAIT_TIMEOUT is too high, (post) requests from the frontend are delayed by 10 seconds.